### PR TITLE
Add set of reusable Actions and Workflows

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Code of Conduct
+
+The standard _Code of Conduct_ that all Eclipse projects must adhere to is defined in the following documents: 
+
+- [Eclipse Code of Conduct](https://raw.githubusercontent.com/eclipse/.github/master/CODE_OF_CONDUCT.md)
+- [Eclipse Foundation Handbook](https://www.eclipse.org/projects/handbook/)
+- [Eclipse Committer Due Diligence Guidelines](https://www.eclipse.org/legal/committerguidelines.php)
+
+We (the committers) aim to run this project in an open and fair manner where contributions are encouraged from all companies and individuals. We aim for high quality, well documented and tested software that can be used in production environments.  
+
+This document shall outline additional roles and responsibilities for committers and project leads to ensure the project is well maintained and supported to be useable in production environments.
+
+## Committers
+
+[Eclipse-uProtocol Committers](https://www.eclipse.org/projects/handbook/#roles-cm) play a vital role to ensure contributions from others (and themselves) follow the vision and mission of the project as well. In this section we will outline how committers are nominated, retired, and their duties while in service.
+
+### Duties
+
+* Contribute to specifications by providing feedback, code contributions in up-spec, up-core-api repos
+* Ensure all contributors (including themselves) adhere to this code of conduct, the Eclipse Foundation Handbook, and the vision & mission of the project
+* Make _significant_ code contributions to one or more repositories in the Eclipse-uProtocol project
+* Review and provide feedback to pull requests from other contributors
+* _Actively_ participate in weekly/bi-weekly project meetings
+
+### Nomination
+
+Contributors are nominated by a uProtocol Committer when they meet the [Eclipse Committer Nomination Process](https://www.eclipse.org/projects/handbook/#elections-committer) requirements and are actively performing the duties of a committer mentioned above.
+
+### Retirement
+
+Per [Eclipse Foundation Handbook](https://www.eclipse.org/projects/handbook/#elections-retire-cm), Committers may retire for one of the following reasons:
+
+* Their own volition
+* By the project lead (with supporting justification)
+
+Non-exhaustive examples for early retirement might be:
+* Inactivity over extended period of time
+* Repeated violations of this code of conduct (ex. obstructing progress during discussions/PRs without
+* valid justification, intentional damage of various repos/projects, etc...)
+
+All communication regarding committer nominations and retirement, *SHALL* be sent to the uprotocol-dev@eclipse.org mailing list.
+
+
+## Project Lead
+
+In addition to the duties mentioned in [Eclipse Contributor Handbook](https://www.eclipse.org/projects/handbook/#roles-pl), project leads *MUST* also fulfill the Committer [Duties defined above](#duties).
+
+
+NOTE: Violation to this code of conduct should be reported to the [Eclipse Foundation Management Office (EMO)](https://gitlab.eclipse.org/eclipsefdn/emo-team/emo/-/issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to Eclipse uProtocol
+
+Thanks for your interest in this project. Contributions are welcome!
+
+## Developer resources
+
+Information regarding source code management, builds, coding standards, and
+more.
+
+<https://projects.eclipse.org/proposals/eclipse-uprotocol>
+
+The project maintains the following source code repositories
+
+<https://github.com/eclipse-uprotocol>
+
+## Eclipse Contributor Agreement
+
+Before your contribution can be accepted by the project team contributors must
+electronically sign the Eclipse Contributor Agreement (ECA).
+
+<http://www.eclipse.org/legal/ECA.php>
+
+Commits that are provided by non-committers must have a Signed-off-by field in
+the footer indicating that the author is aware of the terms by which the
+contribution has been provided to the project. The non-committer must
+additionally have an Eclipse Foundation account and must have a signed Eclipse
+Contributor Agreement (ECA) on file.
+
+For more information, please see the Eclipse Committer Handbook:
+<https://www.eclipse.org/projects/handbook/#resources-commit>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,17 @@
+# Notices for Eclipse uProtocol CI/CD Resources
+
+This content is produced and maintained by the [Eclipse uProtocol project](https://eclipse-uprotocol.github.io).
+
+## Trademarks
+
+Eclipse uProtocol is a trademark of the Eclipse Foundation. Eclipse, and the Eclipse Logo are registered trademarks of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For more information regarding authorship of content, please consult the listed source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0 which is available at <https://www.apache.org/licenses/LICENSE-2.0>.
+
+SPDX-License-Identifier: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# ci-cd
-Shared resources for implementing CI/CD pipelines
+This repository contains common resources which can be used by uProtocol components for implementing CI/CD pipelines.
+
+The [actions](actions/) folder contains reusable GitHub Actions.
+The [workflows](workflows/) folder contains reusable GitHub Workflows.

--- a/actions/run-oft/README.md
+++ b/actions/run-oft/README.md
@@ -1,0 +1,18 @@
+A GitHub Action that runs OpenFastTrace CLI's `trace` command on the local workspace and uploads the report as a workflow artifact.
+
+Considers specification, implementation and documentation artifacts as defined by a list of glob patterns.
+
+The action uses the [standard OpenFastTrace Action](https://github.com/itsallcode/openfasttrace-github-action) for running OpenFastTrace (OFT).
+
+# Inputs
+
+| Name            | Description                                                                                           |
+| :-------------- | :---------------------------------------------------------------------------------------------------- |
+| `file-patterns` | A whitespace separated list of glob patterns which specify the files to include in the OFT trace run. |
+
+# Outputs
+
+| Name                 | Description                                                                                                                                                 |
+| :------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oft-exit-code`      | 0: OFT has run successfully and all specification items are covered<br>> 1: OFT has either failed to run or at least one specification item is not covered. |
+| `tracing-report-url` | The URL pointing to the HTML report that has been created by OFT.                                                                                           |

--- a/actions/run-oft/action.yaml
+++ b/actions/run-oft/action.yaml
@@ -1,0 +1,59 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Perform requirements tracing against a given set of artifacts specified by glob patterns
+# using OpenFastTrace (https://github.com/itsallcode/openfasttrace)
+# Returns the URL of the created HTML report as an output
+
+name: "Run OpenFastTrace"
+description: |
+  Runs OpenFastTrace with the trace command on files in the local workspace.
+inputs:
+  file-patterns:
+    description: |
+      A whitespace separated list of glob patterns which specify the files to include in the OFT trace run.
+    default: "**/*.*"
+    required: false
+outputs:
+  oft-exit-code:
+    description: |
+      The exit code indicating the outcome of running OpenFastTrace (0: success, 1: failure).
+      The report is created in any case, as long as OpenFastTrace could be run at all.
+    value: ${{ steps.run-oft.outputs.oft-exit-code }}
+  tracing-report-url:
+    description: "The URL to the OpenFastTrace HTML report"
+    value: ${{ steps.upload-tracing-report.artifact-url }}
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        # Prepare Environment
+        echo "TRACING_REPORT_FILE_NAME=oft-report.html" >> $GITHUB_ENV
+
+    - name: Run OpenFastTrace
+      id: run-oft
+      uses: itsallcode/openfasttrace-github-action@v0
+      with:
+        file-patterns: ${{ inputs.file-patterns }}
+        report-filename: ${{ env.TRACING_REPORT_FILE_NAME }}
+        report-format: "html"
+
+    - name: Upload tracing report (html)
+      uses: actions/upload-artifact@v4
+      id: upload-tracing-report
+      if: ${{ steps.run-oft.outputs.oft-exit-code != '' }}
+      with:
+        name: tracing-report-html
+        path: ${{ env.TRACING_REPORT_FILE_NAME }}

--- a/workflows/requirements-tracing.yaml
+++ b/workflows/requirements-tracing.yaml
@@ -1,0 +1,58 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Performs requirements tracing using OpenFastTrace (https://github.com/itsallcode/openfasttrace)
+# Uploads tracing report, returns the corresponding download URL as an output
+
+name: Requirements tracing
+
+on:
+  workflow_call:
+    inputs:
+      oft-file-patterns:
+        description: |
+          A whitespace separated list of glob patterns which specify the files to include in the OFT trace run.
+          If not specified, defaults to all files relevant for checking up-rust against the uProtocol Specification.
+        type: string
+    outputs:
+      tracing-report-url:
+        description: 'URL of the requirements tracing report'
+        value: ${{ jobs.tracing.outputs.tracing-report-url }}
+  workflow_dispatch:
+    inputs:
+      oft-file-patterns:
+        description: |
+          A whitespace separated list of glob patterns which specify the files to include in the OFT trace run.
+          If not specified, defaults to all files relevant for checking up-rust against the uProtocol Specification.
+        type: string
+
+jobs:
+  tracing:
+    name: Run OpenFastTrace
+    runs-on: ubuntu-latest
+    outputs:
+      tracing-report-url: ${{ steps.run-oft.outputs.tracing-report-url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Run OpenFastTrace
+        id: run-oft
+        uses: ./.github/actions/run-oft
+        with:
+          file-patterns: ${{ inputs.oft-file-patterns }}
+
+      - name: "Determine exit code"
+        run: |
+          exit ${{ steps.run-oft.outputs.oft-exit-code }}

--- a/workflows/rust/README.md
+++ b/workflows/rust/README.md
@@ -1,0 +1,1 @@
+This folder contains reusable GitHub Action workflows for Rust based uProtocol components.

--- a/workflows/rust/coverage.yaml
+++ b/workflows/rust/coverage.yaml
@@ -1,0 +1,83 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Run all test for all features to collect test code coverage information
+# Upload coverage info for potential re-use in publication workflow, returns the corresponding download URL as an output on workflow_call
+# Can publish coverage info to CodeCov platform, this is controlled by setting CODECOV_TOKEN secret in the github workspace
+
+name: Test coverage
+
+on:
+  workflow_call:
+    outputs:
+      test_coverage_url:
+        description: 'URL of the test coverage artifact'
+        value: ${{ jobs.coverage.outputs.test_coverage_url }}
+  workflow_dispatch:
+          
+env:
+  RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
+  RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always
+          
+jobs:
+  coverage:
+    name: collect
+    runs-on: ubuntu-latest
+    outputs:
+      test_coverage_url: ${{ steps.test_coverage_html.outputs.artifact-url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - uses: dtolnay/rust-toolchain@master
+        with: 
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - name: Install cargo-tarpaulin
+        uses: taiki-e/install-action@cargo-tarpaulin
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run tests and report code coverage
+        run: |
+          # enable nightly features so that we can also include Doctests
+          RUSTC_BOOTSTRAP=1 cargo tarpaulin --workspace --all-features --all-targets --doc -o xml -o lcov -o html
+
+      - name: Upload coverage report (lcov)
+        uses: actions/upload-artifact@v4
+        id: test_coverage_lcov
+        with:
+          name: code-coverage-lcov
+          path: lcov.info
+      - name: Upload coverage report (xml)
+        uses: actions/upload-artifact@v4
+        id: test_coverage_xml
+        with:
+          name: code-coverage-xml
+          path: cobertura.xml
+      - name: Upload coverage report (html)
+        uses: actions/upload-artifact@v4
+        id: test_coverage_html
+        with:
+          name: code-coverage-html
+          path: tarpaulin-report.html
+
+      - name: Upload coverage reports to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ vars.GITHUB_REPOSITORY }}
+          files: lcov.info

--- a/workflows/rust/test-featurematrix.yaml
+++ b/workflows/rust/test-featurematrix.yaml
@@ -1,0 +1,78 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Test all feature combinations on a range of OS platforms
+
+name: Matrix-test
+
+on:
+  workflow_call:
+  workflow_dispatch:
+            
+env:
+  RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
+  RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test-all-features:
+    name: all feature combinations
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - uses: dtolnay/rust-toolchain@master
+        with: 
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-all-features
+        run: |
+            cargo install cargo-all-features
+
+      - name: Show toolchain information
+        working-directory: ${{ github.workspace }}
+        run: |
+          rustup toolchain list
+          cargo --version
+
+      - name: cargo-check all possible feature combinations
+        run: |
+          cargo check-all-features
+      - name: cargo-test all possible feature combinations
+        run: |
+          cargo test-all-features
+
+
+  # Alternative to the full feature matrix tested in the step above - somewhat faster...
+  # multi-os-nextest:
+  #   runs-on: ${{ matrix.os }}
+  #   env: 
+  #     NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macOS-latest]
+  #       feature-flags: ["", "--no-default-features", "--all-features"]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@master
+  #       with: 
+  #         toolchain: ${{ env.RUST_TOOLCHAIN }}
+  #     - uses: Swatinem/rust-cache@v2
+  #     - uses: taiki-e/install-action@nextest
+  #     - name: Run cargo nextest
+  #       run: |
+  #         cargo nextest run --message-format libtest-json-plus ${{ matrix.feature-flags }}

--- a/workflows/rust/verify-latest-deps.yaml
+++ b/workflows/rust/verify-latest-deps.yaml
@@ -1,0 +1,41 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Checks if the crate can be built using the latest stable toolchain with the latest
+# compatible dependencies.
+# The job definition has been inspired by the example given in the Rust Cargo book.
+
+name: Check latest dependencies
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  latest-deps:
+    name: Latest Dependencies
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: allow
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: "recursive"
+    - run: rustup update stable && rustup default stable
+    - run: cargo update --verbose
+    - run: cargo build --verbose --all-features
+    - run: cargo test --verbose --all-features

--- a/workflows/rust/verify-msrv.yaml
+++ b/workflows/rust/verify-msrv.yaml
@@ -1,0 +1,40 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Checks if the MSRV declared in Cargo.toml is correct.
+
+name: Check MSRV
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
+  RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: "recursive"
+    - uses: dtolnay/rust-toolchain@master
+      with: 
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+    - uses: taiki-e/install-action@cargo-hack
+    - name: check MSRV
+      run: |
+        cargo hack check --rust-version --workspace --all-targets --all-features --ignore-private

--- a/workflows/rust/x-build.yaml
+++ b/workflows/rust/x-build.yaml
@@ -1,0 +1,69 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Run all-feature tests on multiple architecture targets
+# Note: tbd whether this adds any actual value...
+
+name: X-platform
+
+on:
+  workflow_call:
+  workflow_dispatch:
+            
+env:
+  RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
+  RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always  
+
+jobs:
+  build:
+    name: build and test
+    runs-on: ${{ matrix.runner }}
+    env: 
+      NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+    strategy:
+      matrix:
+        include:
+          - name: linux-amd64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: linux-arm64
+            runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - name: win-amd64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+          - name: macos-amd64
+            runner: macos-latest
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            runner: macos-latest
+            target: aarch64-apple-darwin
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+     
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: "${{ matrix.target }}"
+      - uses: Swatinem/rust-cache@v2
+      # Using nextest because it's faster than built-in test
+      - uses: taiki-e/install-action@nextest
+     
+      - name: Run cargo nextest
+        run: |
+          cargo nextest run --all-features


### PR DESCRIPTION
Added an initial set of GitHub Actions and Workflows which are aleady being used by several other uProtocol repositories. Once this PR is merged, we can start updating those other repos to refer to the Actions/Workflows instead of keeping a local copy.