### PR TITLE
Support setting cargo deny check command arguments

### DIFF
--- a/.github/workflows/rust-deny-check.yaml
+++ b/.github/workflows/rust-deny-check.yaml
@@ -19,18 +19,19 @@ name: Run cargo-deny checks
 on:
   workflow_call:
     inputs:
-      config-file:
+      command-arguments:
         description: |
-          Path to the cargo-deny configuration file.
-          See https://embarkstudios.github.io/cargo-deny/checks/index.html for details regarding
-          configuration file syntax.
+          Arguments to pass to the check command.
+          See https://embarkstudios.github.io/cargo-deny/cli/check.html for details regarding
+          syntax of the check command.
+          This can for example be used to set a non-default path to the configuration file.
         type: string
         required: false
-        default: ${{ github.workspace }}/deny.toml
       arguments:
         description: |
           Generic arguments to pass on to cargo deny, i.e. arguments
           that are not specific to the check command.
+          See https://embarkstudios.github.io/cargo-deny/cli/common.html for details.
           This can be used to set the path to the Cargo.toml file, if necessary.
         type: string
         required: false
@@ -56,5 +57,5 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check ${{ matrix.checks }}
-          command-arguments: --config ${{ inputs.config-file }}
+          command-arguments: ${{ inputs.command-arguments }}
           arguments: ${{ inputs.arguments }}


### PR DESCRIPTION
We cannot use environment variables in a workflow call's input parameters.
It makes more sense to allow the user to pass in any kind of check command arguments and relying on the default location of the config file being used when no --config arg is set.