### PR TITLE
Restore original script file

### DIFF
--- a/.github/actions/run-eclipse-dash/action.yaml
+++ b/.github/actions/run-eclipse-dash/action.yaml
@@ -32,18 +32,23 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: "Prepare environment"
-      shell: bash
-      run: |
-        # Prepare Environment
-        echo "DASH_SUMMARY=dash-summary.txt" >> $GITHUB_ENV
-
     - name: "Check 3rd party license compatibility"
       id: "run-checks"
       shell: bash
       env:
         DEPS_FILE: ${{ inputs.components-file }}
-      run: ${GITHUB_ACTION_PATH}/check-3rd-party-licenses.sh
+      run: |
+        # Prepare Environment
+        echo "DASH_SUMMARY=dash-summary.txt" >> $GITHUB_ENV
+        if ${GITHUB_ACTION_PATH}/check-3rd-party-licenses.sh
+        then
+          echo "checks-failed=0" >> $GITHUB_OUTPUT
+          echo "License information of 3rd party dependencies has been vetted successfully." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "checks-failed=1" >> $GITHUB_OUTPUT
+          echo "License information of some 3rd party dependencies could not be vetted successfully." >> $GITHUB_STEP_SUMMARY
+          echo "A summary file containing the vetted information has been attached to this workflow run." >> $GITHUB_STEP_SUMMARY
+        fi
 
     - name: "Upload summary file"
       id: upload-summary

--- a/.github/actions/run-eclipse-dash/check-3rd-party-licenses.sh
+++ b/.github/actions/run-eclipse-dash/check-3rd-party-licenses.sh
@@ -18,17 +18,6 @@ dash_summary=${DASH_SUMMARY:-"DASH_SUMMARY.txt"}
 project=${PROJECT:-"automotive.uprotocol"}
 token=${DASH_TOKEN:-""}
 
-function run_dash {
-  args=(-jar "$dash_jar" -timeout 60 -batch 90 -summary "$dash_summary")
-  if [[ -n "$token" ]]; then
-    args=("${args[@]}" -review -token "$token" -project "$project")
-  fi
-  args=("${args[@]}" "$deps_file")
-
-  echo "checking 3rd party licenses..."
-  java "${args[@]}"
-}
-
 if [[ ! -r "$dash_jar" ]]; then
   echo "Eclipse Dash JAR file [${dash_jar}] not found, downloading latest version from GitHub..."
   wget_bin=$(which wget)
@@ -41,12 +30,11 @@ if [[ ! -r "$dash_jar" ]]; then
   fi
 fi
 
-if run_dash
-then
-  echo "checks-failed=0" >> "$GITHUB_OUTPUT"
-  echo "License information of 3rd party dependencies has been vetted successfully." >> "$GITHUB_STEP_SUMMARY"
-else
-  echo "checks-failed=1" >> "$GITHUB_OUTPUT"
-  echo "License information of some 3rd party dependencies could not be vetted successfully." >> "$GITHUB_STEP_SUMMARY"
-  echo "A summary file containing the vetted information has been attached to this workflow run." >> "$GITHUB_STEP_SUMMARY"
+args=(-jar "$dash_jar" -timeout 60 -batch 90 -summary "$dash_summary")
+if [[ -n "$token" ]]; then
+  args=("${args[@]}" -review -token "$token" -project "$project")
 fi
+args=("${args[@]}" "$deps_file")
+
+echo "checking 3rd party licenses..."
+java "${args[@]}"


### PR DESCRIPTION
After having found the real problem with invoking the script from the
action.yaml, the original script file has been restored so that it
can be used from the command line as well (without having to set
the GITHUB_OUTPUT env).