### PR TITLE
Improve coverage workflow

### DIFF
--- a/.github/workflows/rust-coverage.yaml
+++ b/.github/workflows/rust-coverage.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Run tests and report code coverage
         run: |
           # enable nightly features so that we can also include Doctests
-          RUSTC_BOOTSTRAP=1 cargo tarpaulin --workspace --all-features --all-targets --doc -o xml -o lcov -o html
+          RUSTC_BOOTSTRAP=1 cargo tarpaulin --workspace --implicit-test-threads --all-features --all-targets --doc -o xml -o lcov -o html
 
       - name: Upload coverage report (lcov)
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The workflow has been adapted to include the --implicit-test-threads tarpaulin option. This allows tarpaulin to also successfully run cucumber-rs based integration tests when determining code coverage.

Without this option, tarpaulin passes a --test-threads option to the test binary which the cucumber-rs based tests do not support.