### PR TITLE
Fix x-build job

### DIFF
--- a/.github/workflows/rust-x-build.yaml
+++ b/.github/workflows/rust-x-build.yaml
@@ -57,9 +57,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: "${{ matrix.target }}"
       - uses: Swatinem/rust-cache@v2
-      # Using nextest because it's faster than built-in test
-      - uses: taiki-e/install-action@nextest
      
-      - name: Run cargo nextest
+      - name: Run tests
         run: |
-          cargo nextest run --no-fail-fast --all-features
+          cargo test --no-fail-fast --all-features --all-targets


### PR DESCRIPTION
The newly introduced cucumber based integration tests do not use the
standard test harness and therefore do not support the listing of test
cases as part of the cargo nextest run.

The test execution has therefore been adapted to use the standard
cargo test command instead of cargo nextest.