### PR TITLE
Update OpenFastTrace Action to v0.4.0

### DIFF
--- a/.github/actions/run-oft/action.yaml
+++ b/.github/actions/run-oft/action.yaml
@@ -50,7 +50,7 @@ runs:
 
     - name: Run OpenFastTrace
       id: run-oft
-      uses: itsallcode/openfasttrace-github-action@v0.3.0
+      uses: itsallcode/openfasttrace-github-action@v0.4.0
       with:
         file-patterns: ${{ inputs.file-patterns }}
         report-filename: ${{ env.TRACING_REPORT_FILE_NAME }}


### PR DESCRIPTION
Updated the action to use OpenFastTrace version 4.2.0 which includes
support for parsing spec items from TOML files like Cargo.toml.