### PR TITLE
Replace xom9ikk/dotenv action in requirements-tracing workflow

### DIFF
--- a/.github/workflows/requirements-tracing.yaml
+++ b/.github/workflows/requirements-tracing.yaml
@@ -81,10 +81,11 @@ jobs:
 
       - name: "Determine OpenFastTrace parameters from .env file"
         if: inputs.env-file-suffix != ''
-        uses: xom9ikk/dotenv@v2.3.0
+        uses: falti/dotenv-action@v1.2.0
         with:
-          mode: ${{ inputs.env-file-suffix }}
-          load-mode: strict
+          path: ".env.${{ inputs.env-file-suffix }}"
+          export-variables: true
+          keys-case: bypass
 
       - name: Run OpenFastTrace
         id: run-oft


### PR DESCRIPTION
The original dotenv action requires Node 20 to run, which is deprecated bey GitHub Actions. This commit therefore replaces it with falti/dotenv-action which runs on Node 24.