### PR TITLE
Fix MSRV check workflow

### DIFF
--- a/.github/workflows/rust-verify-msrv.yaml
+++ b/.github/workflows/rust-verify-msrv.yaml
@@ -35,9 +35,7 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with: 
         toolchain: ${{ env.RUST_TOOLCHAIN }}
-    - uses: taiki-e/install-action@v1
-      with:
-        tool: cargo-hack
+    - uses: taiki-e/install-action@cargo-hack
     - name: check MSRV
       run: |
         cargo hack check --rust-version --workspace --all-targets --all-features --ignore-private


### PR DESCRIPTION
Adapted the usage of the taiki-e/install-action to install cargo-hack, which is required for the MSRV check. The previous configuration had been using v1 of the action, leading to the installation of an old version of cargo-hack. This, in turn, caused the MSRV check to fail due to the use of the --rust-version flag, which is not supported in older versions of cargo-hack.