### PR TITLE
Pin GitHub Actions used by uProtocol actions

### DIFF
--- a/.github/actions/run-eclipse-dash/action.yaml
+++ b/.github/actions/run-eclipse-dash/action.yaml
@@ -53,7 +53,7 @@ runs:
     - name: "Upload summary file"
       id: upload-summary
       if: ${{ steps.run-checks.outputs.checks-failed == '1' }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: Dash summary report
         path: ${{ env.DASH_SUMMARY }}

--- a/.github/actions/run-eclipse-dash/check-3rd-party-licenses.sh
+++ b/.github/actions/run-eclipse-dash/check-3rd-party-licenses.sh
@@ -18,7 +18,7 @@ dash_summary=${DASH_SUMMARY:-"DASH_SUMMARY.txt"}
 project=${PROJECT:-"automotive.uprotocol"}
 token=${DASH_TOKEN:-""}
 # see https://github.com/eclipse-dash/dash-licenses#get-it
-dash_url="https://repo.eclipse.org/service/rest/v1/search/assets/download?sort=version&repository=dash-maven2-releases&maven.groupId=org.eclipse.dash&maven.artifactId=org.eclipse.dash.licenses&maven.extension=jar"
+dash_url="https://repo.eclipse.org/repository/dash-maven2-releases/org/eclipse/dash/org.eclipse.dash.licenses/1.1.0/org.eclipse.dash.licenses-1.1.0.jar"
 
 if [[ ! -r "$dash_jar" ]]; then
   echo "Eclipse Dash JAR file [${dash_jar}] not found, downloading latest version from GitHub..."

--- a/.github/actions/run-oft/action.yaml
+++ b/.github/actions/run-oft/action.yaml
@@ -50,7 +50,7 @@ runs:
 
     - name: Run OpenFastTrace
       id: run-oft
-      uses: itsallcode/openfasttrace-github-action@v0.4.0
+      uses: itsallcode/openfasttrace-github-action@e302f0817c05efdf45ce863925568c372a0b414e # v0.4.0
       with:
         file-patterns: ${{ inputs.file-patterns }}
         report-filename: ${{ env.TRACING_REPORT_FILE_NAME }}
@@ -58,7 +58,7 @@ runs:
         tags: ${{ inputs.tags }}
 
     - name: Upload tracing report (html)
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       id: upload-tracing-report
       if: ${{ steps.run-oft.outputs.oft-exit-code != '' }}
       with:


### PR DESCRIPTION
This helps to avoid unexpected breakage of our actions when the used GitHub Actions are updated. The pinned versions are the latest versions at the time of this commit.