### PR TITLE
Pin actions to reduce attack surface

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# ********************************************************************************
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directories:
+    - "/.github/workflows"
+    - "/.github/actions"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/requirements-tracing.yaml
+++ b/.github/workflows/requirements-tracing.yaml
@@ -69,7 +69,7 @@ jobs:
     outputs:
       tracing-report-url: ${{ steps.run-oft.outputs.tracing-report-url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: "recursive"
 
@@ -81,7 +81,7 @@ jobs:
 
       - name: "Determine OpenFastTrace parameters from .env file"
         if: inputs.env-file-suffix != ''
-        uses: falti/dotenv-action@v1.2.0
+        uses: falti/dotenv-action@73fafca04177425fd3e0a0849257015ae9d42034 # v1.2.0
         with:
           path: ".env.${{ inputs.env-file-suffix }}"
           export-variables: true
@@ -89,7 +89,7 @@ jobs:
 
       - name: Run OpenFastTrace
         id: run-oft
-        uses: eclipse-uprotocol/ci-cd/.github/actions/run-oft@main
+        uses: eclipse-uprotocol/ci-cd/.github/actions/run-oft@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
         with:
           file-patterns: ${{ env.OFT_FILE_PATTERNS }}
           tags: ${{ env.OFT_TAGS }}

--- a/.github/workflows/rust-coverage.yaml
+++ b/.github/workflows/rust-coverage.yaml
@@ -36,15 +36,17 @@ jobs:
     outputs:
       test_coverage_url: ${{ steps.test_coverage_html.outputs.artifact-url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: "recursive"
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Install cargo-tarpaulin
-        uses: taiki-e/install-action@cargo-tarpaulin
+        uses: taiki-e/install-action@7bc99eee1f1b8902a125006cf790a1f4c8461e63 # v2.69.8
+        with:
+            tool: cargo-tarpaulin
 
       - name: Run tests and report code coverage
         run: |
@@ -52,19 +54,19 @@ jobs:
           RUSTC_BOOTSTRAP=1 cargo tarpaulin --workspace --implicit-test-threads --all-features --all-targets --doc -o xml -o lcov -o html
 
       - name: Upload coverage report (lcov)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         id: test_coverage_lcov
         with:
           name: code-coverage-lcov
           path: lcov.info
       - name: Upload coverage report (xml)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         id: test_coverage_xml
         with:
           name: code-coverage-xml
           path: cobertura.xml
       - name: Upload coverage report (html)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         id: test_coverage_html
         with:
           name: code-coverage-html
@@ -74,7 +76,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ${{ vars.GITHUB_REPOSITORY }}

--- a/.github/workflows/rust-deny-check.yaml
+++ b/.github/workflows/rust-deny-check.yaml
@@ -50,11 +50,11 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: "recursive"
         
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
         with:
           command: check ${{ matrix.checks }}
           command-arguments: ${{ inputs.command-arguments }}

--- a/.github/workflows/rust-license-report.yaml
+++ b/.github/workflows/rust-license-report.yaml
@@ -51,10 +51,10 @@ jobs:
     outputs:
       license_report_url: ${{ steps.license_report.outputs.artifact-url }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: "recursive"
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       with: 
         toolchain: ${{ env.RUST_TOOLCHAIN }}
 
@@ -64,7 +64,7 @@ jobs:
     - name: Create license report
       run: |
         cargo about generate --config ${{ inputs.config }} ${{ inputs.templates }} > licenses.html
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       id: license_report
       with:
         name: license-report

--- a/.github/workflows/rust-test-featurematrix.yaml
+++ b/.github/workflows/rust-test-featurematrix.yaml
@@ -31,10 +31,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: "recursive"
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Install cargo-all-features

--- a/.github/workflows/rust-verify-latest-deps.yaml
+++ b/.github/workflows/rust-verify-latest-deps.yaml
@@ -31,7 +31,7 @@ jobs:
     env:
       CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: allow
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: "recursive"
     - run: rustup update stable && rustup default stable

--- a/.github/workflows/rust-verify-msrv.yaml
+++ b/.github/workflows/rust-verify-msrv.yaml
@@ -29,13 +29,15 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: "recursive"
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       with: 
         toolchain: ${{ env.RUST_TOOLCHAIN }}
-    - uses: taiki-e/install-action@cargo-hack
+    - uses: taiki-e/install-action@7bc99eee1f1b8902a125006cf790a1f4c8461e63 # v2.69.8
+      with:
+        tool: cargo-hack
     - name: check MSRV
       run: |
         cargo hack check --rust-version --workspace --all-targets --all-features --ignore-private

--- a/.github/workflows/rust-x-build.yaml
+++ b/.github/workflows/rust-x-build.yaml
@@ -47,12 +47,12 @@ jobs:
             target: aarch64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: "recursive"
      
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: "${{ matrix.target }}"


### PR DESCRIPTION
Also enabled dependabot for github actions to keep them up to date and reduce the risk of using vulnerable versions of actions.

See https://mikael.barbero.tech/blog/post/2026-03-24-stop-trusting-mutable-references/