### PR TITLE
Set minimum permissions needed for GitHub Actions workflows

### DIFF
--- a/.github/workflows/github-actions-policy-checks.yaml
+++ b/.github/workflows/github-actions-policy-checks.yaml
@@ -18,15 +18,16 @@ name: GitHub Actions Policy Checks
 on:
   workflow_call:
 
-permissions: {}
+permissions:
+  contents: read # needed for checking out the code
 
 jobs:
   poutine:
     name: Check GitHub Workflows using poutine
     runs-on: ubuntu-latest
     permissions:
+      contents: read # needed for checking out the code
       security-events: write # Required for upload-sarif to upload SARIF files.
-      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -42,8 +43,8 @@ jobs:
     name: Run GitHub Actions Security Analysis with zizmor 🌈
     runs-on: ubuntu-latest
     permissions:
+      contents: read # needed for checking out the code
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/requirements-tracing.yaml
+++ b/.github/workflows/requirements-tracing.yaml
@@ -62,7 +62,8 @@ on:
         description: "URL of the requirements tracing report"
         value: ${{ jobs.tracing.outputs.tracing-report-url }}
 
-permissions: {}
+permissions:
+  contents: read # needed for checking out the code
 
 jobs:
   tracing:
@@ -70,8 +71,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tracing-report-url: ${{ steps.run-oft.outputs.tracing-report-url }}
-    permissions:
-      contents: write # Required by the run-oft action for uploading the requirements tracing results as an artifact
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/rust-coverage.yaml
+++ b/.github/workflows/rust-coverage.yaml
@@ -29,7 +29,8 @@ env:
   RUSTFLAGS: -Dwarnings
   CARGO_TERM_COLOR: always
 
-permissions: {}
+permissions:
+  contents: read # needed for checking out the code
 
 jobs:
   coverage:
@@ -37,8 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       test_coverage_url: ${{ steps.test_coverage_html.outputs.artifact-url }}
-    permissions:
-      contents: write # Required for uploading the test coverage results as an artifact
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/rust-deny-check.yaml
+++ b/.github/workflows/rust-deny-check.yaml
@@ -37,7 +37,8 @@ on:
         required: false
         default: --all-features
 
-permissions: {}
+permissions:
+  contents: read # needed for checking out the code
 
 jobs:
   cargo-deny:

--- a/.github/workflows/rust-license-report.yaml
+++ b/.github/workflows/rust-license-report.yaml
@@ -44,7 +44,8 @@ env:
     RUSTFLAGS: -Dwarnings
     CARGO_TERM_COLOR: always
 
-permissions: {}
+permissions:
+  contents: read # needed for checking out the code
 
 jobs:
   license_check:
@@ -52,8 +53,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       license_report_url: ${{ steps.license_report.outputs.artifact-url }}
-    permissions:
-      contents: write # Required for uploading the license report as an artifact
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:

--- a/.github/workflows/rust-test-featurematrix.yaml
+++ b/.github/workflows/rust-test-featurematrix.yaml
@@ -23,7 +23,8 @@ env:
   RUSTFLAGS: -Dwarnings
   CARGO_TERM_COLOR: always
 
-permissions: {}
+permissions:
+  contents: read # needed for checking out the code
 
 jobs:
   test-all-features:

--- a/.github/workflows/rust-verify-latest-deps.yaml
+++ b/.github/workflows/rust-verify-latest-deps.yaml
@@ -23,7 +23,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-permissions: {}
+permissions:
+  contents: read # needed for checking out the code
 
 jobs:
   latest-deps:

--- a/.github/workflows/rust-verify-msrv.yaml
+++ b/.github/workflows/rust-verify-msrv.yaml
@@ -25,7 +25,8 @@ env:
   RUSTFLAGS: -Dwarnings
   CARGO_TERM_COLOR: always
 
-permissions: {}
+permissions:
+  contents: read # needed for checking out the code
 
 jobs:
   check:

--- a/.github/workflows/rust-x-build.yaml
+++ b/.github/workflows/rust-x-build.yaml
@@ -23,7 +23,8 @@ env:
   RUSTFLAGS: -Dwarnings
   CARGO_TERM_COLOR: always  
 
-permissions: {}
+permissions:
+  contents: read # needed for checking out the code
 
 jobs:
   build:


### PR DESCRIPTION
Set contents permission to read for all workflows. Write permissions are not needed for uploading artifacts in the workflows.